### PR TITLE
Lower android minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 21
     }
 }
 


### PR DESCRIPTION
This sets the android `minSdkVersion` to the same one used on the android sdk side